### PR TITLE
Adding a consistent election type

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -260,6 +260,7 @@ class ElectioneeringFactory(BaseFactory):
     class Meta:
         model = models.Electioneering
     idx = factory.Sequence(lambda n: n)
+    election_type_raw = 'G'
 
     @factory.post_generation
     def update_fulltext(obj, create, extracted, **kwargs):

--- a/webservices/common/models/costs.py
+++ b/webservices/common/models/costs.py
@@ -63,12 +63,16 @@ class Electioneering(db.Model):
     disbursement_amount = db.Column('reported_disb_amt', db.Numeric(30, 2), index=True)
     purpose_description = db.Column('disb_desc', db.String)
     report_year = db.Column('rpt_yr', db.Integer, index=True)
-    election_type = db.Column('election_tp', db.String)
     file_number = db.Column('file_num', db.Integer)
     amendment_indicator = db.Column('amndt_ind', db.String)
     receipt_date = db.Column('receipt_dt', db.DateTime)
+    election_type_raw = db.Column('election_tp', db.String)
 
     purpose_description_text = db.Column(TSVECTOR)
+
+    @property
+    def election_type(self):
+        return self.election_type_raw[:1]
 
     @property
     def pdf_url(self):

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -337,8 +337,8 @@ register_schema(CommunicationCostPageSchema)
 
 ElectioneeringSchema = make_schema(
     models.Electioneering,
-    fields={'pdf_url': ma.fields.Str()},
-    options={'exclude': ('idx', 'purpose_description_text')},
+    fields={'pdf_url': ma.fields.Str(), 'election_type': ma.fields.Str()},
+    options={'exclude': ('idx', 'purpose_description_text', 'election_type_raw')},
 )
 ElectioneeringPageSchema = make_page_schema(ElectioneeringSchema, page_type=paging_schemas.SeekPageSchema)
 register_schema(ElectioneeringSchema)


### PR DESCRIPTION
the e-filing records and paper filing had differently represented election types this unifies them to be a little less confusing.
