### PR TITLE
Additional enhancements to the itemized partitioning

### DIFF
--- a/data/functions/utils.sql
+++ b/data/functions/utils.sql
@@ -21,9 +21,11 @@ $$ language plpgsql immutable;
 -- Returns:
 --   The calculated year to use as the transaction date of a record.
 create or replace function get_transaction_year(transaction_date date, report_year numeric)
-returns integer as $$
+returns smallint as $$
+declare
+    transaction_year numeric = coalesce(extract(year from transaction_date), report_year);
 begin
-    return coalesce(extract(year from transaction_date), report_year) + (coalesce(cast(extract(year from transaction_date) as numeric(4, 0)), report_year) % 2);
+    return get_cycle(transaction_year);
 end
 $$ language plpgsql immutable;
 

--- a/data/functions/utils.sql
+++ b/data/functions/utils.sql
@@ -5,6 +5,28 @@ begin
 end
 $$ language plpgsql immutable;
 
+-- Figures out the appropriate year to use for the transaction of a Schedule A
+-- or Schedule B record.  This function is used to fill in the value of the
+-- "transaction_two_year_period" column for the openFEC Schedule A and B tables
+-- and for checking how records should be split for the partitioning of those
+-- tables.  We are splitting by two-year cycles and want to make sure we only
+-- create tables for the cycles, not for every year present in the data.
+
+-- Params:
+--   transaction_date:  the value of the column representing the actual
+--                      transaction date for a given record.
+--   report_year:       the value of the column to use if the transaction_date
+--                      value is NULL.
+
+-- Returns:
+--   The calculated year to use as the transaction date of a record.
+create or replace function get_transaction_year(transaction_date date, report_year numeric)
+returns integer as $$
+begin
+    return coalesce(extract(year from transaction_date), report_year) + (coalesce(cast(extract(year from transaction_date) as numeric(4, 0)), report_year) % 2);
+end
+$$ language plpgsql immutable;
+
 create or replace function election_duration(office text)
 returns integer as $$
 begin

--- a/webservices/config.py
+++ b/webservices/config.py
@@ -13,7 +13,6 @@ def get_cycle_start(year):
 SQL_CONFIG = {
     'START_YEAR': get_cycle_start(1980),
     'START_YEAR_AGGREGATE': get_cycle_start(2008),
-    'START_YEAR_ITEMIZED': get_cycle_start(1978),
     'END_YEAR_ITEMIZED': get_cycle_start(2016),
 }
 

--- a/webservices/config.py
+++ b/webservices/config.py
@@ -13,7 +13,7 @@ def get_cycle_start(year):
 SQL_CONFIG = {
     'START_YEAR': get_cycle_start(1980),
     'START_YEAR_AGGREGATE': get_cycle_start(2008),
-    'START_YEAR_ITEMIZED': get_cycle_start(2012),
+    'START_YEAR_ITEMIZED': get_cycle_start(1978),
     'END_YEAR_ITEMIZED': get_cycle_start(2016),
 }
 

--- a/webservices/partition/base.py
+++ b/webservices/partition/base.py
@@ -78,7 +78,10 @@ class TableGroup:
         select = sa.select(
             parent.columns + cls.timestamp_factory(parent) + cls.column_factory(parent)
         ).where(
-            sa.func.get_transaction_year(parent.c[cls.transaction_date_column], parent.c.rpt_yr).in_([start, stop]),
+            sa.func.get_transaction_year(
+                parent.c[cls.transaction_date_column],
+                parent.c.rpt_yr
+            ).in_([start, stop]),
         )
 
         child = utils.load_table(name)
@@ -103,7 +106,7 @@ class TableGroup:
         cmds = [
             'alter table {child} alter column {primary} set not null',
             'alter table {child} alter column load_date set not null',
-            'alter table {child} add constraint check_transaction_two_year_period check (transaction_two_year_period in ({start}, {stop}))',
+            'alter table {child} add constraint check_transaction_year check (transaction_year in ({start}, {stop}))',
             'alter table {child} inherit {master}'
         ]
         params = {

--- a/webservices/partition/base.py
+++ b/webservices/partition/base.py
@@ -7,7 +7,7 @@ from . import utils
 
 def get_cycles():
     return range(
-        SQL_CONFIG['START_YEAR_ITEMIZED'] - 1,
+        SQL_CONFIG['START_YEAR'] - 1,
         SQL_CONFIG['END_YEAR_ITEMIZED'] + 3,
         2,
     )
@@ -19,7 +19,7 @@ class TableGroup:
     queue_new = None
     queue_old = None
     primary = None
-    date_column = None
+    transaction_date_column = None
 
     columns = []
 
@@ -78,7 +78,7 @@ class TableGroup:
         select = sa.select(
             parent.columns + cls.timestamp_factory(parent) + cls.column_factory(parent)
         ).where(
-            sa.func.get_transaction_year(parent.c[cls.date_column], parent.c.rpt_yr).in_([start, stop]),
+            sa.func.get_transaction_year(parent.c[cls.transaction_date_column], parent.c.rpt_yr).in_([start, stop]),
         )
 
         child = utils.load_table(name)

--- a/webservices/partition/base.py
+++ b/webservices/partition/base.py
@@ -19,6 +19,7 @@ class TableGroup:
     queue_new = None
     queue_old = None
     primary = None
+    date_column = None
 
     columns = []
 
@@ -77,7 +78,7 @@ class TableGroup:
         select = sa.select(
             parent.columns + cls.timestamp_factory(parent) + cls.column_factory(parent)
         ).where(
-            parent.c.rpt_yr.in_([start, stop]),
+            sa.func.get_transaction_year(parent.c[cls.date_column], parent.c.rpt_yr).in_([start, stop]),
         )
 
         child = utils.load_table(name)
@@ -102,7 +103,7 @@ class TableGroup:
         cmds = [
             'alter table {child} alter column {primary} set not null',
             'alter table {child} alter column load_date set not null',
-            'alter table {child} add constraint check_rpt_yr check (rpt_yr in ({start}, {stop}))',
+            'alter table {child} add constraint check_transaction_two_year_period check (transaction_two_year_period in ({start}, {stop}))',
             'alter table {child} inherit {master}'
         ]
         params = {

--- a/webservices/partition/sched_a.py
+++ b/webservices/partition/sched_a.py
@@ -11,7 +11,7 @@ class SchedAGroup(TableGroup):
     queue_new = 'ofec_sched_a_queue_new'
     queue_old = 'ofec_sched_a_queue_old'
     primary = 'sched_a_sk'
-    date_column = 'contb_receipt_dt'
+    transaction_date_column = 'contb_receipt_dt'
 
     columns = [
         sa.Column('timestamp', sa.DateTime),
@@ -42,7 +42,7 @@ class SchedAGroup(TableGroup):
                 parent.c.contbr_id,
                 parent.c.cmte_id,
             ).label('clean_contbr_id'),
-            sa.cast(sa.func.get_transaction_year(parent.c[cls.date_column], parent.c.rpt_yr), sa.Numeric(4, 0)).label('transaction_two_year_period'),
+            sa.cast(sa.func.get_transaction_year(parent.c[cls.transaction_date_column], parent.c.rpt_yr), sa.Numeric(4, 0)).label('transaction_two_year_period'),
         ]
 
     @classmethod

--- a/webservices/partition/sched_a.py
+++ b/webservices/partition/sched_a.py
@@ -21,7 +21,7 @@ class SchedAGroup(TableGroup):
         sa.Column('contributor_occupation_text', TSVECTOR),
         sa.Column('is_individual', sa.Boolean),
         sa.Column('clean_contbr_id', sa.String),
-        sa.Column('transaction_two_year_period', sa.Numeric(4, 0)),
+        sa.Column('transaction_year', sa.SmallInteger),
     ]
 
     @classmethod
@@ -42,7 +42,10 @@ class SchedAGroup(TableGroup):
                 parent.c.contbr_id,
                 parent.c.cmte_id,
             ).label('clean_contbr_id'),
-            sa.cast(sa.func.get_transaction_year(parent.c[cls.transaction_date_column], parent.c.rpt_yr), sa.Numeric(4, 0)).label('transaction_two_year_period'),
+            sa.func.get_transaction_year(
+                parent.c[cls.transaction_date_column],
+                parent.c.rpt_yr
+            ).label('transaction_year'),
         ]
 
     @classmethod
@@ -57,7 +60,7 @@ class SchedAGroup(TableGroup):
             sa.Index(None, c.contbr_city),
             sa.Index(None, c.is_individual),
             sa.Index(None, c.clean_contbr_id),
-            sa.Index(None, c.transaction_two_year_period),
+            sa.Index(None, c.transaction_year),
 
             sa.Index(None, c.contb_receipt_amt, child.c[cls.primary]),
             sa.Index(None, c.contb_receipt_dt, child.c[cls.primary]),

--- a/webservices/partition/sched_a.py
+++ b/webservices/partition/sched_a.py
@@ -11,6 +11,7 @@ class SchedAGroup(TableGroup):
     queue_new = 'ofec_sched_a_queue_new'
     queue_old = 'ofec_sched_a_queue_old'
     primary = 'sched_a_sk'
+    date_column = 'contb_receipt_dt'
 
     columns = [
         sa.Column('timestamp', sa.DateTime),
@@ -20,6 +21,7 @@ class SchedAGroup(TableGroup):
         sa.Column('contributor_occupation_text', TSVECTOR),
         sa.Column('is_individual', sa.Boolean),
         sa.Column('clean_contbr_id', sa.String),
+        sa.Column('transaction_two_year_period', sa.Numeric(4, 0)),
     ]
 
     @classmethod
@@ -40,6 +42,7 @@ class SchedAGroup(TableGroup):
                 parent.c.contbr_id,
                 parent.c.cmte_id,
             ).label('clean_contbr_id'),
+            sa.cast(sa.func.get_transaction_year(parent.c[cls.date_column], parent.c.rpt_yr), sa.Numeric(4, 0)).label('transaction_two_year_period'),
         ]
 
     @classmethod
@@ -54,15 +57,16 @@ class SchedAGroup(TableGroup):
             sa.Index(None, c.contbr_city),
             sa.Index(None, c.is_individual),
             sa.Index(None, c.clean_contbr_id),
+            sa.Index(None, c.transaction_two_year_period),
 
-            sa.Index(None, c.contb_receipt_amt, child.c.sched_a_sk),
-            sa.Index(None, c.contb_receipt_dt, child.c.sched_a_sk),
-            sa.Index(None, c.contb_aggregate_ytd, child.c.sched_a_sk),
+            sa.Index(None, c.contb_receipt_amt, child.c[cls.primary]),
+            sa.Index(None, c.contb_receipt_dt, child.c[cls.primary]),
+            sa.Index(None, c.contb_aggregate_ytd, child.c[cls.primary]),
 
-            sa.Index(None, c.cmte_id, c.sched_a_sk),
-            sa.Index(None, c.cmte_id, c.contb_receipt_amt, c.sched_a_sk),
-            sa.Index(None, c.cmte_id, c.contb_receipt_dt, c.sched_a_sk),
-            sa.Index(None, c.cmte_id, c.contb_aggregate_ytd, c.sched_a_sk),
+            sa.Index(None, c.cmte_id, c[cls.primary]),
+            sa.Index(None, c.cmte_id, c.contb_receipt_amt, c[cls.primary]),
+            sa.Index(None, c.cmte_id, c.contb_receipt_dt, c[cls.primary]),
+            sa.Index(None, c.cmte_id, c.contb_aggregate_ytd, c[cls.primary]),
 
             sa.Index(None, c.contributor_name_text, postgresql_using='gin'),
             sa.Index(None, c.contributor_employer_text, postgresql_using='gin'),

--- a/webservices/partition/sched_b.py
+++ b/webservices/partition/sched_b.py
@@ -11,6 +11,7 @@ class SchedBGroup(TableGroup):
     queue_new = 'ofec_sched_b_queue_new'
     queue_old = 'ofec_sched_b_queue_old'
     primary = 'sched_b_sk'
+    date_column = 'disb_dt'
 
     columns = [
         sa.Column('timestamp', sa.DateTime),
@@ -19,6 +20,7 @@ class SchedBGroup(TableGroup):
         sa.Column('disbursement_description_text', TSVECTOR),
         sa.Column('disbursement_purpose_category', sa.String),
         sa.Column('clean_recipient_cmte_id', sa.String),
+        sa.Column('transaction_two_year_period', sa.Numeric(4, 0)),
     ]
 
     @classmethod
@@ -35,6 +37,7 @@ class SchedBGroup(TableGroup):
                 parent.c.recipient_cmte_id,
                 parent.c.cmte_id,
             ).label('clean_recipient_cmte_id'),
+            sa.cast(sa.func.get_transaction_year(parent.c[cls.date_column], parent.c.rpt_yr), sa.Numeric(4, 0)).label('transaction_two_year_period'),
         ]
 
     @classmethod
@@ -47,13 +50,14 @@ class SchedBGroup(TableGroup):
             sa.Index(None, c.recipient_st),
             sa.Index(None, c.recipient_city),
             sa.Index(None, c.clean_recipient_cmte_id),
+            sa.Index(None, c.transaction_two_year_period),
 
-            sa.Index(None, c.disb_dt, c.sched_b_sk),
-            sa.Index(None, c.disb_amt, c.sched_b_sk),
+            sa.Index(None, c.disb_dt, c[cls.primary]),
+            sa.Index(None, c.disb_amt, c[cls.primary]),
 
-            sa.Index(None, c.cmte_id, c.sched_b_sk),
-            sa.Index(None, c.cmte_id, c.disb_dt, c.sched_b_sk),
-            sa.Index(None, c.cmte_id, c.disb_amt, c.sched_b_sk),
+            sa.Index(None, c.cmte_id, c[cls.primary]),
+            sa.Index(None, c.cmte_id, c.disb_dt, c[cls.primary]),
+            sa.Index(None, c.cmte_id, c.disb_amt, c[cls.primary]),
 
             sa.Index(None, c.recipient_name_text, postgresql_using='gin'),
             sa.Index(None, c.disbursement_description_text, postgresql_using='gin'),

--- a/webservices/partition/sched_b.py
+++ b/webservices/partition/sched_b.py
@@ -11,7 +11,7 @@ class SchedBGroup(TableGroup):
     queue_new = 'ofec_sched_b_queue_new'
     queue_old = 'ofec_sched_b_queue_old'
     primary = 'sched_b_sk'
-    date_column = 'disb_dt'
+    transaction_date_column = 'disb_dt'
 
     columns = [
         sa.Column('timestamp', sa.DateTime),
@@ -37,7 +37,7 @@ class SchedBGroup(TableGroup):
                 parent.c.recipient_cmte_id,
                 parent.c.cmte_id,
             ).label('clean_recipient_cmte_id'),
-            sa.cast(sa.func.get_transaction_year(parent.c[cls.date_column], parent.c.rpt_yr), sa.Numeric(4, 0)).label('transaction_two_year_period'),
+            sa.cast(sa.func.get_transaction_year(parent.c[cls.transaction_date_column], parent.c.rpt_yr), sa.Numeric(4, 0)).label('transaction_two_year_period'),
         ]
 
     @classmethod

--- a/webservices/partition/sched_b.py
+++ b/webservices/partition/sched_b.py
@@ -20,7 +20,7 @@ class SchedBGroup(TableGroup):
         sa.Column('disbursement_description_text', TSVECTOR),
         sa.Column('disbursement_purpose_category', sa.String),
         sa.Column('clean_recipient_cmte_id', sa.String),
-        sa.Column('transaction_two_year_period', sa.Numeric(4, 0)),
+        sa.Column('transaction_year', sa.SmallInteger),
     ]
 
     @classmethod
@@ -37,7 +37,10 @@ class SchedBGroup(TableGroup):
                 parent.c.recipient_cmte_id,
                 parent.c.cmte_id,
             ).label('clean_recipient_cmte_id'),
-            sa.cast(sa.func.get_transaction_year(parent.c[cls.transaction_date_column], parent.c.rpt_yr), sa.Numeric(4, 0)).label('transaction_two_year_period'),
+            sa.func.get_transaction_year(
+                parent.c[cls.transaction_date_column],
+                parent.c.rpt_yr
+            ).label('transaction_year'),
         ]
 
     @classmethod
@@ -50,7 +53,7 @@ class SchedBGroup(TableGroup):
             sa.Index(None, c.recipient_st),
             sa.Index(None, c.recipient_city),
             sa.Index(None, c.clean_recipient_cmte_id),
-            sa.Index(None, c.transaction_two_year_period),
+            sa.Index(None, c.transaction_year),
 
             sa.Index(None, c.disb_dt, c[cls.primary]),
             sa.Index(None, c.disb_amt, c[cls.primary]),

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -13,7 +13,7 @@ from celery_once import QueueOnce
 from webservices import utils
 from webservices.common import counts
 from webservices.common.models import db
-from webservices.resources import candidates, committees, filings, costs, sched_e
+from webservices.resources import candidates, committees, filings, costs, sched_a, sched_b, sched_e
 
 from webservices.tasks import app
 from webservices.tasks import utils as task_utils
@@ -27,6 +27,8 @@ RESOURCE_WHITELIST = {
     filings.FilingsList,
     costs.CommunicationCostView,
     costs.ElectioneeringView,
+    sched_a.ScheduleAView,
+    sched_b.ScheduleBView,
     sched_e.ScheduleEView,
 }
 


### PR DESCRIPTION
@jmcarp, this PR contains the modifications we wanted to make to ensure the partitioning better meets our needs as well as enabling searching and downloading the rest of the data.  Specifically, I've done the following:
- Added a SQL function to calculate the year the transaction record in the Schedule A and B tables by looking at the appropriate columns in each table and extracting the year if found, otherwise falling back to the report year (`rpt_yr`) as we were before.
- Captured the new year value in an additional column in the tables that we create via the partitioning.
- Modified the checks and constraints to utilize the calculated year instead.
- Modified the reference to the primary key to make use of the class variable defined for it - this is in anticipation for the change to shift off the data warehouse versions of these tables soon.
- Changed the start year to calculate cycles with to 1980 (thus starting in 1979).

If anything jumps out at you as incorrect or could be improved, please let me know so I can address it ASAP.  If all looks good, once you merge this then I'll be able to merge your PR into the `develop` branch itself so we can begin testing and having the folks at FEC take a look.

Thanks!
